### PR TITLE
Configure Time between Mastodon Posts

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,6 +4,7 @@
     "twitch_clientID": "TWITCH_API_CLIENT_ID(REQUIRED)",
     "twitch_secret": "TWITCH_API_SECRET(REQUIRED)",
     "ChannelName": "STREAMER_NAME(REQUIRED)",
+    "minHoursBetweenPosts": 6,
     "cron": "*/10 * * * *",
     "twitch_stream_id": "",
     "channels": "",


### PR DESCRIPTION
Moving the function of time between mastodon posts to be able to be configured in config.json rather than be hard coded into twitch-and-toot.js main script 