### PR TITLE
fixed the fact that Kick API is required creds to work

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,7 +89,7 @@ YOUTUBE_API_KEY=YOUR_YOUTUBE_API_KEY
 # Option 2: Use secrets manager (RECOMMENDED - see DOPPLER_GUIDE.md)
 # Comment out the API key above and configure SECRETS section below
 
-# Kick.com Credentials
+# Kick.com Credentials (REQUIRED)
 # HOW TO GET:
 #   1. Login to https://kick.com
 #   2. Make sure 2FA is enabled (Settings → Security)
@@ -97,12 +97,12 @@ YOUTUBE_API_KEY=YOUR_YOUTUBE_API_KEY
 #   4. Create a new application
 #   5. Scopes/Permissions: Select "Read Access" (required for stream status checks)
 #   6. Copy your Client ID and Client Secret
-# NOTE: Kick authentication is OPTIONAL. Without it, Stream Daemon uses public API
-#       (works but has lower rate limits). With auth, you get better reliability.
+# NOTE: Kick API credentials are REQUIRED for stream monitoring.
+#       The public API is no longer supported and will result in 403 errors.
 KICK_ENABLE=False
 # Your Kick username to monitor (used for stream checks and tests)
 KICK_USERNAME=your_kick_username
-# Optional: Kick authentication for better rate limits (recommended)
+# Kick API credentials (REQUIRED when KICK_ENABLE=True)
 # Option 1: Set credentials directly (for testing/local development)
 KICK_CLIENT_ID=YOUR_KICK_CLIENT_ID
 KICK_CLIENT_SECRET=YOUR_KICK_CLIENT_SECRET

--- a/Docker/docker-compose.example.yml
+++ b/Docker/docker-compose.example.yml
@@ -27,9 +27,11 @@ services:
       YOUTUBE_CHANNEL_ID: "your_youtube_channel_id"
       YOUTUBE_API_KEY: "your_youtube_api_key"
       
-      # KICK - No API required for public streams
+      # KICK - Get credentials from: https://kick.com/settings/developer
       KICK_ENABLE: "False"
       KICK_USERNAME: "your_kick_username"
+      KICK_CLIENT_ID: "your_kick_client_id"
+      KICK_CLIENT_SECRET: "your_kick_client_secret"
       
       # ===========================================
       # SOCIAL PLATFORMS (Enable at least ONE)

--- a/Docker/requirements.txt
+++ b/Docker/requirements.txt
@@ -21,7 +21,3 @@ requests==2.32.5
 discord.py==2.6.4
 matrix-nio==0.25.2
 beautifulsoup4==4.14.2
-# Testing framework
-pytest==8.4.2
-pytest-asyncio==1.2.0
-pytest-cov==7.0.0

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Stream Daemon is an enterprise-grade, open-source automation platform for conten
 ### 🎥 Streaming Platform Monitoring
 - **Twitch** - OAuth 2.0 with async API support, rate limiting, comprehensive error handling
 - **YouTube Live** - Auto-resolves channel from @handle or channel ID, quota-aware with retry logic
-- **Kick** - OAuth 2.0 authentication with automatic public API fallback, handles 2FA requirements
+- **Kick** - OAuth 2.0 authentication required, 2FA-enabled developer portal access
 
 ### 📱 Social Media Publishing
 - **Mastodon** - Post to any Mastodon-compatible instance (Mastodon, Hometown, Pleroma, etc.)


### PR DESCRIPTION
Fixing mentions that Kick Public API would work, when it requires an authenticated API now. 