### PR TITLE
pushing python 3.14-slim for docker now that atproto supports it

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,6 +1,6 @@
 # Use an official Python runtime as a parent image
 # Python 3.13 is the latest STABLE version with full package support
-FROM python:3.13-slim
+FROM python:3.14-slim
 
 # Set the working directory in the container to /app
 WORKDIR /app


### PR DESCRIPTION
Upgrading to python 3.14 in docker 