### PR TITLE
fix: Add ollama package to Docker requirements.txt

### DIFF
--- a/Docker/requirements.txt
+++ b/Docker/requirements.txt
@@ -17,6 +17,8 @@ google-genai==1.49.0
 # CVE-2025-4565 fix: Requires protobuf >= 4.25.8 (v4), >= 5.29.5 (v5), or >= 6.31.1 (v6)
 # Using v4 for compatibility; upgrade to v5/v6 requires testing
 protobuf==6.33.0
+# Ollama Python client for local LLM support
+ollama==0.6.1
 # CVE-2024-45590, CVE-2024-42473: Fixed in requests >= 2.32.2
 # CVE-2024-6472: Fixed in requests >= 2.32.4
 # Using latest stable version 2.32.5


### PR DESCRIPTION
The Docker image was missing the ollama Python client package, causing 'Ollama Python client not installed' errors when running in Docker.

This ensures the Docker container has ollama==0.6.1 installed to support local LLM functionality.