### PR TITLE
fix: Add ExecStartPre to stop existing container before restart

### DIFF
--- a/scripts/install-systemd.sh
+++ b/scripts/install-systemd.sh
@@ -362,6 +362,10 @@ User=$ACTUAL_USER
 Group=$ACTUAL_USER
 WorkingDirectory=$PROJECT_DIR
 
+# Stop and remove any existing container before starting
+ExecStartPre=-/usr/bin/docker stop stream-daemon
+ExecStartPre=-/usr/bin/docker rm -f stream-daemon
+
 # Start the Docker container
 ExecStart=/usr/bin/docker run -d \\
     --name stream-daemon \\


### PR DESCRIPTION
The systemd service would fail to restart if a container named stream-daemon already existed. Added ExecStartPre commands to stop and remove any existing container before starting a new one.

The '-' prefix allows the commands to fail silently if the container doesn't exist (first run scenario).