### PR TITLE
Add macvlan network override example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ config.ini
 # Docker user configuration
 Docker/docker-compose.yml
 !Docker/docker-compose.example.yml
+Docker/docker-compose.override.yml
+docker-compose.override.yml
 
 # Test outputs
 tests/__pycache__/

--- a/Docker/docker-compose.macvlan.example.yml
+++ b/Docker/docker-compose.macvlan.example.yml
@@ -1,0 +1,58 @@
+# Macvlan Network Override Example
+# ============================================================
+# Use this to place the container on a macvlan network with a
+# static IP on your LAN. Useful for VLAN segmentation or when
+# you need the bot to appear as its own host on the network.
+#
+# Setup:
+#   1. Create the macvlan network (adjust parent/subnet for your LAN):
+#      docker network create -d macvlan \
+#        --subnet=192.168.1.0/24 \
+#        --gateway=192.168.1.1 \
+#        -o parent=eth0 \
+#        my-macvlan
+#
+#   2. Copy this file to the repo root as docker-compose.override.yml:
+#      cp Docker/docker-compose.macvlan.example.yml docker-compose.override.yml
+#
+#      Or if running from the Docker/ directory:
+#      cp docker-compose.macvlan.example.yml docker-compose.override.yml
+#
+#   3. Edit the IP address, DNS, and network name to match your setup.
+#
+#   4. Start normally — the override is picked up automatically:
+#      docker compose up -d
+#
+# Alternatively, create a root-level docker-compose.yml that references
+# the GHCR image directly (bypassing the build-context compose in Docker/):
+#
+#   services:
+#     stream-daemon:
+#       image: ghcr.io/chiefgyk3d/stream-daemon:latest
+#       container_name: stream-daemon
+#       restart: unless-stopped
+#       env_file: .env
+#       volumes:
+#         - ./messages.txt:/app/messages.txt:ro
+#         - ./end_messages.txt:/app/end_messages.txt:ro
+#       networks:
+#         my-macvlan:
+#           ipv4_address: 192.168.1.51
+#       dns:
+#         - 192.168.1.1
+#   networks:
+#     my-macvlan:
+#       external: true
+# ============================================================
+
+services:
+  stream-daemon:
+    networks:
+      my-macvlan:
+        ipv4_address: 192.168.1.51
+    dns:
+      - 192.168.1.1
+
+networks:
+  my-macvlan:
+    external: true


### PR DESCRIPTION
Adds `Docker/docker-compose.macvlan.example.yml` for deploying the bot on a Docker macvlan network with a static LAN IP.

## What
- New file: `Docker/docker-compose.macvlan.example.yml`
- Updated `.gitignore` to exclude `docker-compose.override.yml` (both root and Docker/ level)

## Usage
1. Create a macvlan Docker network on your host
2. Copy `Docker/docker-compose.macvlan.example.yml` to `Docker/docker-compose.override.yml`
3. Edit the IP address, DNS, and network name for your environment
4. Run `docker compose up -d` — the override is picked up automatically

Includes a commented alternative for running with GHCR images at the repo root level.

## Why
Useful for VLAN-segmented setups where the container needs its own IP on the LAN. This is optional — the default bridge networking continues to work as before.